### PR TITLE
Sub main

### DIFF
--- a/src/routes/MyPage.js
+++ b/src/routes/MyPage.js
@@ -291,6 +291,8 @@ const MyPage = () => {
   );
 };
 
+
+
 function MemberPwUpdate({ userPw, closeModal, user }) {
   // 비밀번호 변경 변수들 (현재 비밀번호, 새 비밀번호, 새 비밀번호 확인용)
   const [currentUserPw, setCurrentUserPw] = useState("");
@@ -314,50 +316,11 @@ function MemberPwUpdate({ userPw, closeModal, user }) {
     setConfirmCurrentUserPw(false); // Reset error state
     setConfirmNewUserPw(false); // Reset error state
 
-<<<<<<< HEAD
-// 비밀번호 변경 모달창
-function MemberPwUpdate({userPw, closeModal, user}) {
-    //비밀번호 변경 변수들 (현재 비밀번호, 새 비밀번호, 새 비밀번호 확인용)
-    const [currentUserPw, setCurrentUserPw] = useState('');
-    const [newUserPw, setNewUserPw] = useState('');
-    const [confirmUserPw, setConfirmUserPw] = useState('');
-    const maxLength = 20; // 최대 글자 수 설정
-    const [confirmCurrentUserPw, setConfirmCurrentUserPw] = useState(false);
-    const [confirmNewUserPw,setConfirmNewUserPw] = useState(false);
-
-    const handleCurrentUserPw = (event) => { 
-        setCurrentUserPw(event.target.value); }
-    const handleNewUserPw = (e) => { setNewUserPw(e.target.value); }
-    const handleConfirmUserPw = (e) => { setConfirmUserPw(e.target.value); }
-
-    const changeUserPw = () => {
-        if(currentUserPw != userPw){
-            setConfirmCurrentUserPw(true);
-        }
-        if(newUserPw != confirmUserPw) {
-            setConfirmNewUserPw(true);
-            
-        }
-        
-        if(userPw == currentUserPw && newUserPw == confirmUserPw){
-            let member = {userPw : newUserPw}
-            //axios로 비밀번호 변경
-            updateMember(user.id,member)
-            .then((res)=> {
-                console.log("비밀번호 변경 성공!")
-                sessionStorage.setItem('user', JSON.stringify(res.data));             
-                closeModal();
-            });
-        }   
-            
-        
-=======
     if (currentUserPw !== userPw) {
       setConfirmCurrentUserPw(true);
     }
     if (newUserPw !== confirmUserPw) {
       setConfirmNewUserPw(true);
->>>>>>> 806023a1f1076eb8c876da1cd45267c9ff2e7eaf
     }
 
     if (currentUserPw === userPw && newUserPw === confirmUserPw) {
@@ -433,40 +396,6 @@ function MemberPwUpdate({userPw, closeModal, user}) {
             </span>
           </div>
 
-<<<<<<< HEAD
-                <div className="input-container">
-                    <input type="text" value={newUserPw} placeholder="새 비밀번호"
-                    onChange={handleNewUserPw} className="input-underline"/>
-                    
-                    <span className="char-count">
-                    {newUserPw.length}/{maxLength}
-                    </span>
-                </div>
-
-                <div className="input-container">
-                    <input type="text" value={confirmUserPw} placeholder="비밀번호 확인"
-                    onChange={handleConfirmUserPw} className="input-underline"/>
-                    
-                    {confirmNewUserPw && <span className="error-message">
-                        현재 비밀번호가 일치하지 않습니다.</span>}
-                    
-                    <span className="char-count">
-                    {confirmUserPw.length}/{maxLength}
-                    </span>  
-                </div>
-
-                <div className="button-container">
-                    <button className='btn modal-close-btn' onClick={()=>{
-                            
-                            changeUserPw();
-                        
-                    }}>
-                        변경
-                    </button>
-                    <button className='btn modal-close-btn' onClick={()=>closeModal() }>닫기</button>
-                </div>
-            </div>
-=======
           <div className="button-container">
             <button className="btn modal-close-btn" onClick={changeUserPw}>
               변경
@@ -475,7 +404,6 @@ function MemberPwUpdate({userPw, closeModal, user}) {
               닫기
             </button>
           </div>
->>>>>>> 806023a1f1076eb8c876da1cd45267c9ff2e7eaf
         </div>
       </div>
     </>

--- a/src/routes/MyPage.js
+++ b/src/routes/MyPage.js
@@ -272,8 +272,7 @@ const MyPage = () => {
 
 
 
-
-
+// 비밀번호 변경 모달창
 function MemberPwUpdate({userPw, closeModal, user}) {
     //비밀번호 변경 변수들 (현재 비밀번호, 새 비밀번호, 새 비밀번호 확인용)
     const [currentUserPw, setCurrentUserPw] = useState('');
@@ -336,8 +335,6 @@ function MemberPwUpdate({userPw, closeModal, user}) {
                 <div className="input-container">
                     <input type="text" value={newUserPw} placeholder="새 비밀번호"
                     onChange={handleNewUserPw} className="input-underline"/>
-                    
-                    
                     
                     <span className="char-count">
                     {newUserPw.length}/{maxLength}

--- a/src/routes/MyPage.js
+++ b/src/routes/MyPage.js
@@ -1,68 +1,22 @@
 import "./css/MyPage.css";
 import React, { useEffect, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import defaultImage from "../images/bg.jpg";
+import defaultImage from "../images/default.jpg";
 import { updateMember } from "../services/MemberService.js";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 const MyPage = () => {
-  const user = JSON.parse(sessionStorage.getItem("user")); // 세션에서 사용자 이름 가져오기
+  const userSession = JSON.parse(sessionStorage.getItem("user")); // 세션에서 사용자 이	름 가져오기
   const isLoggedIn = sessionStorage.getItem("isLoggedIn"); // 로그인 여부 확인
-
-  // 유저 이미지 관리 변수 및 함수
-  const [image, setImage] = useState(defaultImage);
-  const handleImageChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setImage(reader.result);
-      };
-      reader.readAsDataURL(file); // 이미지 파일을 base64 URL로 변환
-    }
-  };
-
-  // 이메일 변경
-  const [email, setEmail] = useState("");
-  const [userPw, setUserPw] = useState("");
-  const [userName, setUserName] = useState("");
-
-  const setUserState = () => {
-    setEmail(user.email);
-    setUserPw(user.userPw);
-    setUserName(user.name);
-  };
-
-  const [isEditingEmail, setIsEditingEmail] = useState(false);
-
-  const handleSaveEmail = () => {
-    // 이메일 저장 로직 추가
-    setIsEditingEmail(false);
-  };
-
-  // 유저 이름 변경
-  const [isEditingUserName, setIsEditingUserName] = useState(false);
-
-  const handleSaveUserName = () => {
-    setIsEditingUserName(false);
-  };
-
-  // 모달 창
-  const [modalOpen, setModalOpen] = useState(false);
-  const closeModal = () => {
-    setModalOpen(false);
-  };
-
+  let [user,setUser] = useState(userSession);
+console.log(user);
   let navigate = useNavigate();
   useEffect(() => {
     if (!isLoggedIn || !user) {
       alert("로그인을 하셔야합니다.");
       navigate("/login"); // 로그인되지 않았거나 사용자 정보가 없는 경우 로그인 페이지로 이동
       return;
-    }
-    if (user) {
-      setUserState();
     }
   }, [isLoggedIn, user]);
 
@@ -102,24 +56,64 @@ const MyPage = () => {
 
         {/* 오른쪽 부분 */}
         <div className="rightContent">
-          <h4 style={{ marginTop: "20px", fontWeight: "bold" }}>프로필 정보</h4>
-          <hr
-            style={{
-              border: "none",
-              width: "80%",
-              height: "5px",
-              backgroundColor: "black",
-            }}
-          />
+			<h4 style={{ marginTop: "20px", fontWeight: "bold" }}>프로필 정보</h4>
+			<hr
+				style={{
+				border: "none",
+				width: "80%",
+				height: "5px",
+				backgroundColor: "black",
+				}}
+			/>
 
-          {/* 이미지랑 이름 */}
-          <div className="myPageSection1">
+			{/* 이미지랑 이름 */}
+			<MyPageSection1 user={user} setUser={setUser} />
+			
+			<hr style={{ width: "80%" }} />
+			<br />
+
+			{/* 로그인 정보 블록 */}
+			<MyPageSection2 user={user} setUser={setUser}/>
+
+			{/* 개인 정보 칸 */}
+		  	<MyPageSection3 user={user} />
+        </div>
+      </div>
+      <ToastContainer />
+    </>
+  );
+};
+
+// 프로필 사진 컴포넌트
+function MyPageSection1({user,setUser}) {
+	// 유저 이미지 관리 변수 및 함수
+	const [image, setImage] = useState(user.userImage || defaultImage);
+
+	
+	// !!!이미지 바뀌면 sessionStorage에서 userImage값이 바뀌게 했는데 데이터베이스까지 연동시키려면 서버에 이미지 저장하고
+	// 데이터베이스에는 url만 저장하는게 효과적이라는데 흠...
+	const handleImageChange = (event) => {
+	  const file = event.target.files[0];
+	  if (file) {
+		const reader = new FileReader();
+		reader.onloadend = () => {
+		  setImage(reader.result);
+		  const updatedUser = { ...user, userImage: reader.result };
+		  setUser(updatedUser);
+		  sessionStorage.setItem("user", JSON.stringify(updatedUser));
+
+		};
+		reader.readAsDataURL(file); // 이미지 파일을 base64 URL로 변환
+	  }
+	};
+	return (
+		<>
+		<div className="myPageSection1">
             {/* 이미지 부분 */}
             <div style={{ padding: "15px" }}>
-              <button
-                className="btn"
-                style={{ cursor: "pointer", border: "none" }}
-              >
+				<button
+                	className="btn"
+                	style={{ cursor: "pointer", border: "none" }}>
                 <img
                   src={image}
                   alt="Description"
@@ -127,57 +121,87 @@ const MyPage = () => {
                     width: "100px",
                     height: "100px",
                     borderRadius: "50%",
-                  }}
-                />
+                  }}/>
               </button>
             </div>
 
             {/* 이름 부분 */}
             <div>
-              <span
-                style={{
-                  fontWeight: "bold",
-                  fontSize: "26px",
-                  display: "inline-block",
-                  marginBottom: "10px",
-                }}
-              >
-                {user.name} 님
-              </span>
-              <br />
-              <input
-                type="file"
-                accept="image/*"
-                style={{ display: "none" }}
-                id="imageUpload"
-                onChange={handleImageChange}
-              />
-              <label
-                htmlFor="imageUpload"
-                className="btn"
-                style={{ fontSize: "12px", cursor: "pointer" }}
-              >
-                이미지 변경
-              </label>
-              <button
-                className="btn"
-                style={{ fontSize: "12px", marginLeft: "15px" }}
-                onClick={() => {
-                  console.log(image);
-                }}
-              >
-                삭제
-              </button>
-            </div>
-          </div>
+              	<span
+					style={{
+						fontWeight: "bold",
+                  		fontSize: "26px",
+                  		display: "inline-block",
+                  		marginBottom: "10px",
+                }}>
+					{user.name} 님
+            	</span>
+              	<br />
+              	<input
+                	type="file"
+                	accept="image/*"
+                	style={{ display: "none" }}
+                	id="imageUpload"
+                	onChange={handleImageChange}/>
+              	<label
+                	htmlFor="imageUpload"
+                	className="btn"
+                	style={{ fontSize: "12px", cursor: "pointer" }}
+				>
+					이미지 변경
+				</label>
+				<button
+					className="btn"
+					style={{ fontSize: "12px", marginLeft: "15px" }}
+					onClick={() => {
+					console.log(image);
+				}}>
+					삭제
+				</button>
+			</div>
+		</div>
+		</>
+	)
+}
 
-          <hr style={{ width: "80%" }} />
-          <br />
 
-          {/* 로그인 정보 블록 */}
-          <div className="myPageSection2">
-            <h5 style={{ fontWeight: "bold" }}>로그인 정보</h5>
+// 로그인 정보 컴포넌트
+function MyPageSection2({user, setUser}) {
+	const [userEmail, setUserEmail] = useState(user.email);
+	const [isEditingEmail, setIsEditingEmail] = useState(false);
+	const handleSaveEmail = () => {
+	// 이메일 저장 로직 추가
+	setIsEditingEmail(false);
+	};
 
+	// 모달 창
+	const [modalOpen, setModalOpen] = useState(false);
+	const closeModal = () => {
+	  setModalOpen(false);
+	};
+
+	//이메일 변경 로직
+	const changeUserEmail= () => {
+		let member = { email: userEmail };
+      // Update email via API call
+      updateMember(user.id, member)
+        .then((res) => {
+			const updatedUser = {...user, email:userEmail}
+			setUser(updatedUser);
+			console.log("이메일 변경 성공!");
+			sessionStorage.setItem("user", JSON.stringify(res.data));
+			toast.success("이메일 변경이 완료되었습니다."); // Show success toast
+        })
+        .catch((error) => {
+          console.error("이메일 변경 실패", error);
+          toast.error("이메일 변경에 실패했습니다."); // Show error toast
+        });
+	}
+
+	return (
+		<>
+		<div className="myPageSection2">
+			<h5 style={{ fontWeight: "bold" }}>로그인 정보</h5>
             {/* 이메일 부분 */}
             <div className="list">
               <div>
@@ -186,13 +210,13 @@ const MyPage = () => {
 
                 {isEditingEmail ? (
                   <input
-                    type="text"
+                    type="email"
                     className="form-control"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    value={userEmail}
+                    onChange={(e) => setUserEmail(e.target.value)}
                   />
                 ) : (
-                  <span>{email}</span>
+                  <span>{userEmail}</span>
                 )}
               </div>
 
@@ -202,6 +226,7 @@ const MyPage = () => {
                 onClick={() => {
                   if (isEditingEmail) {
                     handleSaveEmail(); // 이메일 저장 로직 실행
+					changeUserEmail();
                   } else {
                     setIsEditingEmail(true); // 수정 모드로 전환
                   }
@@ -219,195 +244,227 @@ const MyPage = () => {
 
                 <span>{"●".repeat(8)}</span>
               </div>
-              <button
-                className="btn"
-                type="button"
-                onClick={() => {
-                  setModalOpen(true);
-                }}
-              >
-                변경
-              </button>
+              	<button
+					className="btn"
+					type="button"
+					onClick={() => {
+                  		setModalOpen(true);
+            	}}>
+                	변경
+              	</button>
 
-              {modalOpen && (
+              	{modalOpen && (
                 <MemberPwUpdate
-                  userPw={userPw}
                   closeModal={closeModal}
                   user={user}
+				  setUser={setUser}
                 />
-              )}
+              	)}
             </div>
-          </div>
-
-          {/* 개인 정보 칸 */}
-          <div className="myPageSection3">
-            <h5 style={{ fontWeight: "bold" }}>개인 정보</h5>
-
-            <div className="list">
-              <div>
-                <label>이름</label> <br />
-                {isEditingUserName ? (
-                  <input
-                    type="text"
-                    className="form-control"
-                    value={userName}
-                    onChange={(e) => setUserName(e.target.value)}
-                  />
-                ) : (
-                  <span>{userName}</span>
-                )}
-              </div>
-              <div>
-                <button
-                  className="btn"
-                  type="button"
-                  onClick={() => {
-                    if (isEditingUserName) {
-                      handleSaveUserName(); // 이름 저장 로직 실행
-                    } else {
-                      setIsEditingUserName(true); // 수정 모드로 전환
-                    }
-                  }}
-                >
-                  {isEditingUserName ? "저장" : "변경"}
-                </button>
-              </div>
-            </div>
-            <div className="list">
-              <div>
-                <label>휴대폰 번호</label>
-                <br />
-                <span>{user.phone}</span>
-              </div>
-              <button className="btn" type="button">
-                변경
-              </button>
-            </div>
-          </div>
         </div>
-      </div>
-      <ToastContainer />
-    </>
-  );
-};
+		</>
+	)
+}
+
+// 비밀번호 변경 모달창
+// !!! 비밀번호 변경 시에 setUser로 user객체 바꾸고 sessionStorage에도 변경된 값으로 set
+function MemberPwUpdate({closeModal, user, setUser}) {
+	const [userPw, setUserPw] = useState(user.userPw);
+	// 비밀번호 변경 변수들 (현재 비밀번호, 새 비밀번호, 새 비밀번호 확인용)
+	const [currentUserPw, setCurrentUserPw] = useState("");
+	const [newUserPw, setNewUserPw] = useState("");
+	const [confirmUserPw, setConfirmUserPw] = useState("");
+	const maxLength = 20; // 최대 글자 수 설정
+	const [confirmCurrentUserPw, setConfirmCurrentUserPw] = useState(false);
+	const [confirmNewUserPw, setConfirmNewUserPw] = useState(false);
+
+	const handleCurrentUserPw = (event) => {
+		setCurrentUserPw(event.target.value);
+	};
+	const handleNewUserPw = (e) => {
+		setNewUserPw(e.target.value);
+	};
+	const handleConfirmUserPw = (e) => {
+		setConfirmUserPw(e.target.value);
+	};
+
+	const changeUserPw = () => {
+		// setConfirmCurrentUserPw(false); // Reset error state
+		// setConfirmNewUserPw(false); // Reset error state
+
+		if (currentUserPw !== userPw) {
+		setConfirmCurrentUserPw(true);
+		}
+		if (newUserPw !== confirmUserPw) {
+		setConfirmNewUserPw(true);
+		}
+
+		if (currentUserPw === userPw && newUserPw === confirmUserPw) {
+		let member = { userPw: newUserPw };
+		// Update password via API call
+		updateMember(user.id, member)
+			.then((res) => {
+				const updatedUser = { ...user, userPw: newUserPw };
+				setUser(updatedUser);
+				console.log("비밀번호 변경 성공!");
+				sessionStorage.setItem("user", JSON.stringify(res.data));
+				toast.success("비밀번호 변경이 완료되었습니다."); // Show success toast
+				closeModal();
+			})
+			.catch((error) => {
+			console.error("비밀번호 변경 실패", error);
+			toast.error("비밀번호 변경에 실패했습니다."); // Show error toast
+			});
+		}
+	};
+
+ 	return (
+    	<>
+      	<div className={"modal-container"}>
+        	<div className={"modal-content"}>
+			<h3>비밀번호 변경</h3>
+			<hr />
+			<br />
+			<div className="input-container">
+				<input
+				type="password"
+				value={currentUserPw}
+				placeholder="현재 비밀번호"
+				onChange={handleCurrentUserPw}
+				className="input-underline"
+				/>
+				{confirmCurrentUserPw && (
+				<span className="error-message">
+					현재 비밀번호가 일치하지 않습니다.
+				</span>
+				)}
+				<span className="char-count">
+				{currentUserPw.length}/{maxLength}
+				</span>
+			</div>
+
+			<div className="input-container">
+				<input
+				type="password"
+				value={newUserPw}
+				placeholder="새 비밀번호"
+				onChange={handleNewUserPw}
+				className="input-underline"
+				/>
+				<span className="char-count">
+				{newUserPw.length}/{maxLength}
+				</span>
+			</div>
+
+			<div className="input-container">
+				<input
+				type="password"
+				value={confirmUserPw}
+				placeholder="비밀번호 확인"
+				onChange={handleConfirmUserPw}
+				className="input-underline"
+				/>
+				{confirmNewUserPw && (
+				<span className="error-message">
+					새 비밀번호가 일치하지 않습니다.
+				</span>
+				)}
+				<span className="char-count">
+				{confirmUserPw.length}/{maxLength}
+				</span>
+			</div>
+
+			<div className="button-container">
+				<button className="btn modal-close-btn" onClick={changeUserPw}>
+				변경
+				</button>
+				<button className="btn modal-close-btn" onClick={closeModal}>
+				닫기
+				</button>
+			</div>
+			</div>
+		</div>
+		</>
+  	);
+}
 
 
 
-function MemberPwUpdate({ userPw, closeModal, user }) {
-  // 비밀번호 변경 변수들 (현재 비밀번호, 새 비밀번호, 새 비밀번호 확인용)
-  const [currentUserPw, setCurrentUserPw] = useState("");
-  const [newUserPw, setNewUserPw] = useState("");
-  const [confirmUserPw, setConfirmUserPw] = useState("");
-  const maxLength = 20; // 최대 글자 수 설정
-  const [confirmCurrentUserPw, setConfirmCurrentUserPw] = useState(false);
-  const [confirmNewUserPw, setConfirmNewUserPw] = useState(false);
+// 개인 정보 컴포넌트
+function MyPageSection3({user}) {
+	const [userName,setUserName] = useState(user.name);
+	// 유저 이름 변경
+	const [isEditingUserName, setIsEditingUserName] = useState(false);
 
-  const handleCurrentUserPw = (event) => {
-    setCurrentUserPw(event.target.value);
-  };
-  const handleNewUserPw = (e) => {
-    setNewUserPw(e.target.value);
-  };
-  const handleConfirmUserPw = (e) => {
-    setConfirmUserPw(e.target.value);
-  };
+	const handleSaveUserName = () => {
+	  setIsEditingUserName(false);
+	};
 
-  const changeUserPw = () => {
-    setConfirmCurrentUserPw(false); // Reset error state
-    setConfirmNewUserPw(false); // Reset error state
-
-    if (currentUserPw !== userPw) {
-      setConfirmCurrentUserPw(true);
-    }
-    if (newUserPw !== confirmUserPw) {
-      setConfirmNewUserPw(true);
-    }
-
-    if (currentUserPw === userPw && newUserPw === confirmUserPw) {
-      let member = { userPw: newUserPw };
-      // Update password via API call
+	const changeUserName = () => {
+		let member = { email: userName };
+      // Update email via API call
       updateMember(user.id, member)
         .then((res) => {
-          console.log("비밀번호 변경 성공!");
+          console.log("이메일 변경 성공!");
           sessionStorage.setItem("user", JSON.stringify(res.data));
-          toast.success("비밀번호 변경이 완료되었습니다."); // Show success toast
-          closeModal();
+          toast.success("이메일 변경이 완료되었습니다."); // Show success toast
         })
         .catch((error) => {
-          console.error("비밀번호 변경 실패", error);
-          toast.error("비밀번호 변경에 실패했습니다."); // Show error toast
+          console.error("이메일 변경 실패", error);
+          toast.error("이메일 변경에 실패했습니다."); // Show error toast
         });
-    }
-  };
+	}
+	return(
+		<>
+		<div className="myPageSection3">
+			<h5 style={{ fontWeight: "bold" }}>개인 정보</h5>
 
-  return (
-    <>
-      <div className={"modal-container"}>
-        <div className={"modal-content"}>
-          <h3>비밀번호 변경</h3>
-          <hr />
-          <br />
-          <div className="input-container">
-            <input
-              type="password"
-              value={currentUserPw}
-              placeholder="현재 비밀번호"
-              onChange={handleCurrentUserPw}
-              className="input-underline"
-            />
-            {confirmCurrentUserPw && (
-              <span className="error-message">
-                현재 비밀번호가 일치하지 않습니다.
-              </span>
-            )}
-            <span className="char-count">
-              {currentUserPw.length}/{maxLength}
-            </span>
-          </div>
+			<div className="list">
+				<div>
+					<label>이름</label> <br />
+					{isEditingUserName ? (
+					<input
+						type="text"
+						className="form-control"
+						value={userName}
+						onChange={(e) => setUserName(e.target.value)}
+					/>
+					) : (
+					<span>{userName}</span>
+					)}
+				</div>
+				<div>
+					<button
+					className="btn"
+					type="button"
+					onClick={() => {
+						if (isEditingUserName) {
+						handleSaveUserName(); // 이름 저장 로직 실행
+						} else {
+						setIsEditingUserName(true); // 수정 모드로 전환
+						}
+					}}
+					>
+					{isEditingUserName ? "저장" : "변경"}
+					</button>
+				</div>
+			</div>
 
-          <div className="input-container">
-            <input
-              type="password"
-              value={newUserPw}
-              placeholder="새 비밀번호"
-              onChange={handleNewUserPw}
-              className="input-underline"
-            />
-            <span className="char-count">
-              {newUserPw.length}/{maxLength}
-            </span>
-          </div>
-
-          <div className="input-container">
-            <input
-              type="password"
-              value={confirmUserPw}
-              placeholder="비밀번호 확인"
-              onChange={handleConfirmUserPw}
-              className="input-underline"
-            />
-            {confirmNewUserPw && (
-              <span className="error-message">
-                새 비밀번호가 일치하지 않습니다.
-              </span>
-            )}
-            <span className="char-count">
-              {confirmUserPw.length}/{maxLength}
-            </span>
-          </div>
-
-          <div className="button-container">
-            <button className="btn modal-close-btn" onClick={changeUserPw}>
-              변경
-            </button>
-            <button className="btn modal-close-btn" onClick={closeModal}>
-              닫기
-            </button>
-          </div>
-        </div>
-      </div>
-    </>
-  );
+			<div className="list">
+				<div>
+					<label>휴대폰 번호</label>
+					<br />
+					<span>{user.phone}</span>
+				</div>
+				<button className="btn" type="button">
+					변경
+				</button>
+			</div>
+		</div>
+		</>
+	)
 }
+
+
 
 export default MyPage;


### PR DESCRIPTION
FEAT: 이미지, 이메일, 비밀번호 부분 추가 구현하였습니다.
1. 이미지 변경 누르면 데이터베이스에 저장하지는 않고 웹에 sessionstorage에만 userImage값으로 저장해놓기만 했습니다.
2. 이메일에서는 바꾸고 저장을 누르면 서버에 요청 보내서 email 값 바뀌게 구현했습니다.
3. 비밀번호는 변경된 값을 user객체와 sessionstorage에 user에 적용되도록 구현했습니다.

DOCS : 이미지 부분, 로그인 정보 부분, 비밀번호 변경 모달창, 개인 정보 부분 4가지의 컴포넌트로 나누었습니다.